### PR TITLE
Wait to resolve user auth before routing to list, history, reports pages

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,5 +1,15 @@
 var greenlistApp = angular.module("greenlistApp", ["ngRoute", "firebase"]);
 
+greenlistApp.run(["$rootScope", "$location", function($rootScope, $location) {
+    $rootScope.$on("$routeChangeError", function(event, next, previous, error) {
+        // We can catch the error thrown when the $requireSignIn promise is rejected
+        // and redirect the user back to the home page
+        if (error === "AUTH_REQUIRED") {
+            $location.path("/login");
+        }
+    });
+}]);
+
 greenlistApp.config(["$routeProvider", function($routeProvider) {
     $routeProvider
         .when("/login", {
@@ -7,18 +17,38 @@ greenlistApp.config(["$routeProvider", function($routeProvider) {
         })
         .when("/list", {
             templateUrl: "views/html/shopping.html",
-            controller: "ShoppingListCtrl"
+            controller: "ShoppingListCtrl",
+            resolve: {
+                "CurrentAuth": ["Auth", function(Auth) {
+                    return Auth.$requireSignIn();
+                }]
+            }
         })
         .when("/history", {
             templateUrl: "views/html/history.html",
-            controller: "HistoryListCtrl"
+            controller: "HistoryListCtrl",
+            resolve: {
+                "CurrentAuth": ["Auth", function(Auth) {
+                    return Auth.$requireSignIn();
+                }]
+            }
         })
         .when("/reports", {
             templateUrl: "views/html/report.html",
-            controller: "ReportCtrl"
+            controller: "ReportCtrl",
+            resolve: {
+                "CurrentAuth": ["Auth", function(Auth) {
+                    return Auth.$requireSignIn();
+                }]
+            }
         })
         .otherwise({
-            redirectTo: "/list"
+            redirectTo: "/login"
         });
 
-}])
+}]);
+
+greenlistApp.factory("Auth", ["$firebaseAuth",
+    function($firebaseAuth) {
+        return $firebaseAuth();
+    }]);

--- a/app/controllers/HistoryListCtrl.js
+++ b/app/controllers/HistoryListCtrl.js
@@ -1,3 +1,3 @@
-greenlistApp.controller("HistoryListCtrl", ["$scope", "UserInfo", function($scope, UserInfo) {
+greenlistApp.controller("HistoryListCtrl", ["CurrentAuth", "$scope", "UserInfo", function(CurrentAuth, $scope, UserInfo) {
 
 }]);

--- a/app/controllers/ReportCtrl.js
+++ b/app/controllers/ReportCtrl.js
@@ -1,3 +1,3 @@
-greenlistApp.controller("ReportCtrl", ["$scope", "UserInfo", function($scope, UserInfo) {
+greenlistApp.controller("ReportCtrl", ["CurrentAuth", "$scope", "UserInfo", function(CurrentAuth, $scope, UserInfo) {
 
 }]);

--- a/app/controllers/ShoppingListCtrl.js
+++ b/app/controllers/ShoppingListCtrl.js
@@ -1,3 +1,3 @@
-greenlistApp.controller("ShoppingListCtrl", ["$scope", "UserInfo", function($scope, UserInfo) {
+greenlistApp.controller("ShoppingListCtrl", ["CurrentAuth", "$scope", "UserInfo", function(CurrentAuth, $scope, UserInfo) {
 
 }]);

--- a/app/services/UserInfoService.js
+++ b/app/services/UserInfoService.js
@@ -1,9 +1,9 @@
 greenlistApp.service("UserInfo", function() {
     var currentUser = {};
 
-    function initUser(userName, uid, photoUrl) {
+    function initUser(displayName, uid, photoUrl) {
         console.log("Setting up user");
-        currentUser.userName = userName;
+        currentUser.displayName = displayName;
         currentUser.uid = uid;
         currentUser.photoUrl = photoUrl;
     }


### PR DESCRIPTION
Use the AngularFire `$requireSignIn` method to ensure users are auth'd before loading views that require user data. This fixes the issue with the future database reference service where the UID for a user wasn't retrieved in time to make database queries/binds.