### PR TITLE
Handle modal errors and add more info

### DIFF
--- a/public/app/controllers/ShoppingListCtrl.js
+++ b/public/app/controllers/ShoppingListCtrl.js
@@ -75,6 +75,12 @@ greenlistApp.controller("ShoppingListCtrl",
                 }
 
             })
+
+            modalInstance.result.then(function(data) {
+                console.log("Modal got data", data);
+            }).catch(function(err) {
+                console.error(err);
+            })
         }
 
         $scope.toggleCheck = function(item, status) {

--- a/public/views/css/base.css
+++ b/public/views/css/base.css
@@ -219,6 +219,7 @@ input[type=range]::-moz-range-thumb {
 	font-size: 3vh;
 	text-align: center;
 	padding: 3vh;
+	padding-bottom: 2vh;
 }
 
 .confirmation .modal-dialog button {
@@ -238,4 +239,9 @@ input[type=range]::-moz-range-thumb {
 	border-bottom-left-radius: 0;
 	border-bottom-right-radius: 10px;
 	border-left: white solid 1px;
+}
+
+.confirmation .modal-dialog p {
+	text-align: center;
+	padding: 0 3vh 0 3vh;
 }

--- a/public/views/html/confirmation.html
+++ b/public/views/html/confirmation.html
@@ -1,5 +1,6 @@
 <div>
     <h4>Are you sure you want to clear your list?</h4>
+    <p>Any brand new, unchecked items will be deleted! Checked and previously purchased items will move to History.</p>
     <button type="button" ng-click="archive()">Yes</button>
     <button id="no-btn" type="button" ng-click="mistake()">No</button>
 </div>


### PR DESCRIPTION
Expanded on the body text of the modal and catch the rejected promise when the modal is tapped off