### PR TITLE
Omit brand new items from averages and top items

### DIFF
--- a/public/app/services/QueryService.js
+++ b/public/app/services/QueryService.js
@@ -97,8 +97,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
         var newItem = {
             list: "shopping",
             name: itemName.toLowerCase(),
-            checked: false,
-            average: -1
+            checked: false
         };
 
         if (newItem.name == "uuddlrlrba") {
@@ -378,7 +377,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
 
            data.forEach(function(item) {
 
-               if (item.val().average != -1) {
+               if (item.val().average != null) {
                    console.log("Adding " + item.val().average);
                    dataArray.push(item.val().average);
                }
@@ -436,7 +435,8 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
      * @param callback The callback function
      */
     function getTopEfficient(callback) {
-        DatabaseRef.items().orderByChild("average").limitToLast(3).once("value").then(function(data) {
+        DatabaseRef.items().orderByChild("average").once("value").then(function(data) {
+            console.log(data.val());
             var dataArray = [];
 
             data.forEach(function(item) {
@@ -453,7 +453,8 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
      * @param callback The callback function
      */
     function getBottomEfficient(callback) {
-        DatabaseRef.items().orderByChild("average").limitToFirst(3).once("value").then(function(data) {
+        DatabaseRef.items().orderByChild("average").once("value").then(function(data) {
+            console.log(data.val());
             var dataArray = [];
 
             data.forEach(function(item) {

--- a/public/app/services/QueryService.js
+++ b/public/app/services/QueryService.js
@@ -18,7 +18,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
 
             //controller for the modal
             controller:function($scope, $uibModalInstance){
-                if (status === true){
+                if (status){
                     $scope.cancel = true;
                 }
                 else {
@@ -36,7 +36,13 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
                  * close without logging waste
                  */
                 $scope.later = function() {
-                    $uibModalInstance.close(null); // Pass null if there isn't any data
+
+                    if (status) {
+                        $uibModalInstance.close(null); // Pass null if there isn't any data
+                    } else {
+                        $uibModalInstance.close("deferred");
+                    }
+
                 }
 
 
@@ -46,7 +52,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
 
         // get score from modal
         modalInstance.result.then(function (data) {
-
+            console.log(data);
             //set the modal button to cancel or ask me later
             if (data === null) {
 
@@ -55,16 +61,20 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
                 callback(null)
             } else {
                 console.log("Got from modal:", data);
-                var wasteScore = {
-                    date: Date.now(),
-                    score: parseInt(data)
-                };
 
-                var push = DatabaseRef.wasteData(item).push();
-                push.set(wasteScore);
-                updateWasteDataStatus(item, true);
-                setItemAverage(item);
-                updateOverallAverage();
+                if (data !== "deferred") {
+                    var wasteScore = {
+                        date: Date.now(),
+                        score: parseInt(data)
+                    };
+
+                    var push = DatabaseRef.wasteData(item).push();
+                    push.set(wasteScore);
+                    updateWasteDataStatus(item, true);
+                    setItemAverage(item);
+                    updateOverallAverage();
+                }
+
                 callback(true);
             }
         }).catch(function(error) {
@@ -88,7 +98,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
             list: "shopping",
             name: itemName.toLowerCase(),
             checked: false,
-            average: 0
+            average: -1
         };
 
         if (newItem.name == "uuddlrlrba") {
@@ -114,7 +124,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
                         checkWasteDataStatus(newItem, function(dataUpdated) {
                             if (!dataUpdated) {
                                 // TODO Show modal and ask user for waste data
-                                updateWasteScore(newItem, function(gotData) {
+                                updateWasteScore(newItem, false, function(gotData) {
                                     if (gotData) {
                                         setItemList(newItem, "shopping");
                                     }
@@ -276,7 +286,7 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
      * @param item The item to get data for
      * @param callback The callback function
      */
-    function getChartData(item, callback) {
+    function getChartData(item, status, callback) {
         DatabaseRef.wasteData(item).orderByChild("date").once("value").then(function(data) {
             var scoresArray = [];
             var datesArray = [];
@@ -367,7 +377,12 @@ greenlistApp.service("DatabaseQuery", ["DatabaseRef", "CalculationService", "$ui
            var dataArray = [];
 
            data.forEach(function(item) {
-              dataArray.push(item.val().average);
+
+               if (item.val().average != -1) {
+                   console.log("Adding " + item.val().average);
+                   dataArray.push(item.val().average);
+               }
+
            });
 
            callback(dataArray);

--- a/public/app/services/ReferenceService.js
+++ b/public/app/services/ReferenceService.js
@@ -73,7 +73,7 @@ greenlistApp.service("DatabaseRef", ["UserInfo", function(UserInfo) {
      * @returns firebase reference location to top 3 items
      */
     function topEfficient(){
-        return items().orderByChild("average").limitToLast(3);
+        return items().orderByChild("average").startAt(0).limitToLast(3);
     }
 
     /**
@@ -81,7 +81,7 @@ greenlistApp.service("DatabaseRef", ["UserInfo", function(UserInfo) {
      * @returns firebase reference location to bottom 3 items
      */
     function bottomEfficient(){
-        return items().orderByChild("average").limitToFirst(3);
+        return items().orderByChild("average").startAt(0).limitToFirst(3);
     }
 
     /**

--- a/public/views/html/history.html
+++ b/public/views/html/history.html
@@ -12,7 +12,7 @@
 					<div class="col-xs-8 itemrow">
 						<p class="shopping-item">{{food.name}}</p>
 						<!-- Waste bar -->
-						<div ng-show="food.average != -1" class="col-xs-12 colourbar" ng-style="getBackColor(food.average)">
+						<div ng-show="food.average != null" class="col-xs-12 colourbar" ng-style="getBackColor(food.average)">
 							<div class="innerbar" ng-style="getBarColor(food.average)">
 							</div>
 							<p>{{food.average | number: 0}}%</p>

--- a/public/views/html/history.html
+++ b/public/views/html/history.html
@@ -12,7 +12,7 @@
 					<div class="col-xs-8 itemrow">
 						<p class="shopping-item">{{food.name}}</p>
 						<!-- Waste bar -->
-						<div class="col-xs-12 colourbar" ng-style="getBackColor(food.average)">
+						<div ng-show="food.average != -1" class="col-xs-12 colourbar" ng-style="getBackColor(food.average)">
 							<div class="innerbar" ng-style="getBarColor(food.average)">
 							</div>
 							<p>{{food.average | number: 0}}%</p>

--- a/public/views/html/shopping.html
+++ b/public/views/html/shopping.html
@@ -24,7 +24,7 @@
 						<!-- item name injected here-->
 						<p class="shopping-item">{{item.name}}</p>
 						<!-- Waste bar -->
-						<div class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
+						<div ng-show="item.average != -1" class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
 							<div class="innerbar" ng-style="getBarColor(item.average)">
 							</div>
 							<p>{{item.average | number: 0}}%</p>
@@ -65,7 +65,7 @@
 						<!-- item name injected here-->
 						<p class="shopping-item checked-item">{{item.name}}</p>
 						<!-- Waste bar -->
-						<div class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
+						<div ng-show="item.average != -1" class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
 							<div class="innerbar"  ng-style="getBarColor(item.average)">
 							</div>
 							<p>{{item.average | number: 0}}%</p>

--- a/public/views/html/shopping.html
+++ b/public/views/html/shopping.html
@@ -24,7 +24,7 @@
 						<!-- item name injected here-->
 						<p class="shopping-item">{{item.name}}</p>
 						<!-- Waste bar -->
-						<div ng-show="item.average != -1" class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
+						<div ng-show="item.average != null" class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
 							<div class="innerbar" ng-style="getBarColor(item.average)">
 							</div>
 							<p>{{item.average | number: 0}}%</p>
@@ -65,7 +65,7 @@
 						<!-- item name injected here-->
 						<p class="shopping-item checked-item">{{item.name}}</p>
 						<!-- Waste bar -->
-						<div ng-show="item.average != -1" class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
+						<div ng-show="item.average != null" class="col-xs-12 colourbar" ng-style="getBackColor(item.average)">
 							<div class="innerbar"  ng-style="getBarColor(item.average)">
 							</div>
 							<p>{{item.average | number: 0}}%</p>


### PR DESCRIPTION
Only add the average key once some data has been logged. Otherwise only take in account items with data when calculating averages and displaying top items on reports.